### PR TITLE
Renamed a parameter so that the fraction value passed to RHDrawImageInRect is correct

### DIFF
--- a/RHAdditions/NSImage+RHResizableImageAdditions.m
+++ b/RHAdditions/NSImage+RHResizableImageAdditions.m
@@ -161,8 +161,8 @@ RHEdgeInsets RHEdgeInsetsFromString(NSString* string){
         arc_release_nil(_cachedImageRep);
         _cachedImageSize = NSZeroSize;
         _cachedImageDeviceScale = 0.0f;
+        _cachedImageRep = nil;
     }
-    
     
     //if we don't have a cached image rep, create one now
     if (!_cachedImageRep){

--- a/RHAdditions/NSImage+RHResizableImageAdditions.m
+++ b/RHAdditions/NSImage+RHResizableImageAdditions.m
@@ -161,7 +161,6 @@ RHEdgeInsets RHEdgeInsetsFromString(NSString* string){
         arc_release_nil(_cachedImageRep);
         _cachedImageSize = NSZeroSize;
         _cachedImageDeviceScale = 0.0f;
-        _cachedImageRep = nil;
     }
     
     //if we don't have a cached image rep, create one now

--- a/RHAdditions/NSImage+RHResizableImageAdditions.m
+++ b/RHAdditions/NSImage+RHResizableImageAdditions.m
@@ -332,7 +332,7 @@ CGFloat RHContextGetDeviceScale(CGContextRef context){
 
 
 
-void RHDrawNinePartImage(NSRect frame, NSImage *topLeftCorner, NSImage *topEdgeFill, NSImage *topRightCorner, NSImage *leftEdgeFill, NSImage *centerFill, NSImage *rightEdgeFill, NSImage *bottomLeftCorner, NSImage *bottomEdgeFill, NSImage *bottomRightCorner, NSCompositingOperation op, CGFloat alphaFraction, BOOL shouldTile){
+void RHDrawNinePartImage(NSRect frame, NSImage *topLeftCorner, NSImage *topEdgeFill, NSImage *topRightCorner, NSImage *leftEdgeFill, NSImage *centerFill, NSImage *rightEdgeFill, NSImage *bottomLeftCorner, NSImage *bottomEdgeFill, NSImage *bottomRightCorner, NSCompositingOperation op, CGFloat fraction, BOOL shouldTile){
     
     CGFloat imageWidth = frame.size.width;
     CGFloat imageHeight = frame.size.height;


### PR DESCRIPTION
Renamed a parameter so that the fraction value passed to RHDrawImageInRect is the param value rather than something out of Carbon's Script.h header.

Also, fixed the cached image representation invalidation logic.
