### PR TITLE
RHResizableImage now implements NSCopying protocol

### DIFF
--- a/RHAdditions/NSImage+RHResizableImageAdditions.h
+++ b/RHAdditions/NSImage+RHResizableImageAdditions.h
@@ -76,7 +76,7 @@ typedef enum NSInteger {
 
 
 
-@interface RHResizableImage : NSImage {
+@interface RHResizableImage : NSImage <NSCopying> {
     //ivars are private
     RHEdgeInsets _capInsets;
     RHResizableImageResizingMode _resizingMode;

--- a/RHAdditions/NSImage+RHResizableImageAdditions.m
+++ b/RHAdditions/NSImage+RHResizableImageAdditions.m
@@ -131,7 +131,19 @@ RHEdgeInsets RHEdgeInsetsFromString(NSString* string){
     return self;
 }
 
+- (id)copyWithZone:(NSZone *)zone
+{
+    RHResizableImage *ri = [super copyWithZone: zone];
 
+    ri->_capInsets = _capInsets;
+    ri->_imagePieces = arc_retain(_imagePieces);
+    ri->_cachedImageRep = arc_retain(_cachedImageRep);
+    ri->_cachedImageSize = _cachedImageSize;
+    ri->_cachedImageDeviceScale = _cachedImageDeviceScale;
+    ri->_resizingMode = _resizingMode;
+
+    return ri;
+}
 
 -(void)dealloc{
     arc_release_nil(_imagePieces);


### PR DESCRIPTION
- some AppKit classes will copy images rather than retain them.
- implementing copyWithZone prevents crashes due to RHReziableImage’s
  instance variables now being copied
